### PR TITLE
travis-ci: download non-qa version of fuse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
 
 install:
-  - wget https://www.fusetools.com/downloads/0.25.1.7608/osx -O fuse-installer.pkg
+  - wget https://www.fusetools.com/downloads/0.25.1.7615/osx -O fuse-installer.pkg
   - sudo installer -pkg fuse-installer.pkg -target /
 
 script:


### PR DESCRIPTION
It seems I missed a bit and added a version of Fuse from the QA
channel rather than from the Beta channel. This release got nuked,
so the build currently errors due to a 404.

Let's switch to the latest version from the Beta channel instead.
