### PR TITLE
Fix ARC Issue

### DIFF
--- a/NativeControls/iOS/DateExtensions.uno
+++ b/NativeControls/iOS/DateExtensions.uno
@@ -34,7 +34,7 @@ namespace Native.iOS
 
             NSCalendar* calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 			NSDate* date = [calendar dateFromComponents:components];
-			[components release];
+			[components autorelease];
 
 			return date;
 		@}

--- a/NativeControls/iOS/DateExtensions.uno
+++ b/NativeControls/iOS/DateExtensions.uno
@@ -34,7 +34,6 @@ namespace Native.iOS
 
             NSCalendar* calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 			NSDate* date = [calendar dateFromComponents:components];
-			[components autorelease];
 
 			return date;
 		@}


### PR DESCRIPTION
Remove "release" call for Fuse 0.35 release (turned on ARC). Ref #7 

Fuse Changelog: https://www.fusetools.com/downloads
"Uno has now enabled automatic reference-counting (ARC) in Foreign Objective-C code. If you have foreign code and Xcode complains about methods like dealloc, retain, release, or autorelease being unavailable, this can be fixed by removing the calls to those methods."